### PR TITLE
Fix: Handle Gemini API rate limit

### DIFF
--- a/src/generate_report.py
+++ b/src/generate_report.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import json
 import yaml
+import time
 import google.generativeai as genai
 import summarize_pdf
 from json_to_markdown import json_to_markdown
@@ -103,6 +104,8 @@ def is_relevant(summary, topic_description, model, threshold=0.5):
     """
     prompt = f"Is the following paper summary relevant to the topic description?\n\nSummary: {summary}\n\nTopic Description: {topic_description}\n\nAnswer with a relevance score between 0 and 1. No explanation is needed"
     response = model.generate_content(prompt)
+    # The Gemini free tier has a rate limit of 15 RPM
+    time.sleep(5)
     relevance_score = float(response.text.strip())
     return relevance_score
 

--- a/src/test_generate_report.py
+++ b/src/test_generate_report.py
@@ -32,6 +32,6 @@ def test_inflate_prompt(setup_files):
     topics_string = "\n".join([f"{index + 1}. {topic['topic']}\n{topic['description']}" for index, topic in enumerate(topics)])
 
     expected_prompt = f"This is a prompt template with Sample paper data. and {topics_string}."
-    generated_prompt = inflate_prompt(str(prompt_template_path), str(paper_data_path), str(topics_path))
+    generated_prompt, _ = inflate_prompt(str(prompt_template_path), str(paper_data_path), str(topics_path))
 
     assert generated_prompt == expected_prompt


### PR DESCRIPTION
This commit addresses the Gemini API rate limit issue by introducing a delay between API calls.

- Added a 5-second sleep in the `is_relevant` function in `src/generate_report.py` to ensure the rate limit of 15 RPM is not exceeded.
- Fixed a bug in `src/test_generate_report.py` that was causing an assertion error.